### PR TITLE
Add CI pipeline and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[test]
+      - name: Run tests
+        run: pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/*
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.venv/
+build/
+dist/
+.eggs/
+*.egg-info/
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,14 @@
 This repository contains a Home Assistant custom integration that exposes an iPod connected to a Raspberry Pi as a `media_player` entity. The integration communicates with a FastAPI backend running on the Pi.
 
 See `custom_components/ipod_dock/README.md` for setup instructions.
+
+## Development
+
+Run tests with:
+
+```bash
+pip install -e .[test]
+pytest
+```
+
+When a tag starting with `v` is pushed, GitHub Actions builds the package and creates a release with the distribution archives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ha-ipod-entity"
+version = "1.0.0"
+description = "Home Assistant iPod Dock integration"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "httpx>=0.25.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-asyncio",
+]
+
+[tool.setuptools]
+package-dir = {"" = "custom_components"}
+packages = ["ipod_dock"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"ipod_dock" = ["*"]

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1,0 +1,70 @@
+import sys
+import types
+import pytest
+
+# Create stub homeassistant modules
+hass = types.ModuleType("homeassistant")
+components = types.ModuleType("homeassistant.components")
+media_player = types.ModuleType("homeassistant.components.media_player")
+core = types.ModuleType("homeassistant.core")
+config_entries = types.ModuleType("homeassistant.config_entries")
+
+class MediaPlayerEntity:
+    pass
+
+class MediaPlayerEntityFeature:
+    PLAY = 1
+    PAUSE = 2
+    NEXT_TRACK = 4
+    PREVIOUS_TRACK = 8
+    PLAY_MEDIA = 16
+
+class MediaPlayerState(str):
+    IDLE = "idle"
+    UNAVAILABLE = "unavailable"
+
+media_player.MediaPlayerEntity = MediaPlayerEntity
+media_player.MediaPlayerEntityFeature = MediaPlayerEntityFeature
+media_player.MediaPlayerState = MediaPlayerState
+core.HomeAssistant = type("HomeAssistant", (), {})
+config_entries.ConfigEntry = type("ConfigEntry", (), {})
+
+sys.modules["homeassistant"] = hass
+sys.modules["homeassistant.components"] = components
+sys.modules["homeassistant.components.media_player"] = media_player
+sys.modules["homeassistant.core"] = core
+sys.modules["homeassistant.config_entries"] = config_entries
+
+from ipod_dock.media_player import IpodMediaPlayer
+
+class DummyResponse:
+    def __init__(self, json_data=None, status_code=200):
+        self._json = json_data or {}
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP error")
+
+    def json(self):
+        return self._json
+
+class DummyClient:
+    def __init__(self):
+        self.posts = []
+        self.gets = []
+
+    async def get(self, url):
+        self.gets.append(url)
+        return DummyResponse({"state": "playing", "title": "Song", "artist": "Artist"})
+
+    async def post(self, url, json=None):
+        self.posts.append((url, json))
+        return DummyResponse()
+
+@pytest.mark.asyncio
+async def test_play_media_posts_request():
+    client = DummyClient()
+    player = IpodMediaPlayer(client, "Test Player")
+    await player.async_play_media("music", "Song")
+    assert ("/player/play_media", {"title": "Song"}) in client.posts


### PR DESCRIPTION
## Summary
- add a pytest stub test
- document development workflow
- configure packaging via `pyproject.toml`
- add GitHub Actions for testing and release
- add `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684df425bde08323a9a34aafd16a8013